### PR TITLE
feature: Add --print-log flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ docker-compose-wait
 docker-compose-wait -f <path_to_yaml_file> -f <path_to_other_yaml_file> ...
 ```
 
+## Running tests
+
+```
+python -m pip install -r requirements.txt # install dependencies
+brew install bats-core # install test runner
+
+bats tests.bats # run tests
+```
+
 ## License
 
 [See the license file](https://github.com/nicolas-van/docker-compose-wait/blob/master/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ optional arguments:
                         compose.yml files, example: 5s, 10m,... ). If there is
                         a timeout this command will exit returning 1.
                         (default: wait for an infinite amount of time)
+  -l, --log-print       Whether to print docker healthcheck output for
+                        unhealthy services
 ```
 
 Basically it can be as simple as:


### PR DESCRIPTION
```
python ./docker_compose_wait.py -l -f $dc
Some processes failed:
test is down
"{"Status":"unhealthy","FailingStreak":53,"Log":[{"Start":"2020-07-06T14:37:54.8364676Z","End":"2020-07-06T14:37:54.9433973Z","ExitCode":1,"Output":""},{"Start":"2020-07-06T14:37:55.9578003Z","End":"2020-07-06T14:37:56.0626704Z","ExitCode":1,"Output":""},{"Start":"2020-07-06T14:37:57.0732574Z","End":"2020-07-06T14:37:57.1770289Z","ExitCode":1,"Output":""},{"Start":"2020-07-06T14:37:58.1892991Z","End":"2020-07-06T14:37:58.2964073Z","ExitCode":1,"Output":""},{"Start":"2020-07-06T14:37:59.3065727Z","End":"2020-07-06T14:37:59.4156385Z","ExitCode":1,"Output":""}]}"
```